### PR TITLE
Webpay form is created by a form class and correctly processed

### DIFF
--- a/src/AppBundle/Controller/WebpayController.php
+++ b/src/AppBundle/Controller/WebpayController.php
@@ -2,11 +2,11 @@
 
 namespace AppBundle\Controller;
 
-use AppBundle\Entity\Post;
-use http\Env\Request;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use AppBundle\Form\WebPay\WebpayPayType;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Post controller.
@@ -16,35 +16,67 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 class WebpayController extends Controller
 {
     /**
-     * Lists all post entities.
-     *
      * @Route("/", name="webpay_index")
      * @Method("GET")
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     public function indexAction()
     {
-        //$em = $this->getDoctrine()->getManager();
+        $form = $this->createForm(
+            WebpayPayType::class,
+            null,
+            [
+                'action' => $this->generateUrl('webpay_process_payment'),
+                'method' => 'POST',
+            ]
+        );
 
-        //$posts = $em->getRepository('AppBundle:Post')->findAll();
-
-        return $this->render('@App/webpay/index.html.twig', array(
-            'prueba' => 'prueba',
-        ));
+        return $this->render(
+            '@App/webpay/index.html.twig',
+            [
+                'form' => $form->createView(),
+            ]
+        );
     }
 
     /**
-     * @Route("/pagar", name="webpay_pagar")
+     * @Route("/pagar", name="webpay_process_payment")
      * @Method("POST")
      *
+     * @param Request $request
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function pagarAction(Post $post){
+    public function pagarAction(Request $request)
+    {
+        $form = $this->createForm(
+            WebpayPayType::class,
+            null,
+            [
+                'action' => $this->generateUrl('webpay_process_payment'),
+                'method' => 'POST',
+            ]
+        );
 
-        var_dump('gola');
-        die();
+        $form->handleRequest($request);
 
-        return $this->redirectToRoute('post_edit', array('id' => 3));
+        if ($form->isSubmitted() && $form->isValid()) {
+            $data = $form->getData();
 
+            return $this->render(
+                '@App/webpay/pagar.html.twig',
+                [
+                    'data' => $data,
+                ]
+            );
+        }
 
-
+        return $this->render(
+            '@App/webpay/index.html.twig',
+            [
+                'form' => $form->createView(),
+            ]
+        );
     }
 }

--- a/src/AppBundle/Form/WebPay/WebpayPayType.php
+++ b/src/AppBundle/Form/WebPay/WebpayPayType.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace AppBundle\Form\WebPay;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class WebpayPayType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('amount', NumberType::class);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'app_bundle_webpay_pay_type';
+    }
+}

--- a/src/AppBundle/Resources/views/webpay/index.html.twig
+++ b/src/AppBundle/Resources/views/webpay/index.html.twig
@@ -2,11 +2,10 @@
 
 {% block body %}
     <h1>Web pay</h1>
-
-    <form method="post" action="{{ path('webpay_pagar') }}">
-        <!--<a href="{{ path('webpay_pagar') }}">Pagar $1.000</a>-->
-        <input type="text" name="valor" value="1000">
-        <input type="submit" value="Pagar $1.000">
-    </form>
+    {{ form_start(form) }}
+    {{ form_widget(form.amount) }}
+    {{ form_errors(form.amount) }}
+    <input type="submit" value="Pagar">
+    {{ form_end(form) }}
 
 {% endblock %}

--- a/src/AppBundle/Resources/views/webpay/pagar.html.twig
+++ b/src/AppBundle/Resources/views/webpay/pagar.html.twig
@@ -1,7 +1,8 @@
 {% extends 'base.html.twig' %}
 
 {% block body %}
-    <h1>pagar...</h1>
+    <h1>Pagado!</h1>
+    {{ dump(data) }}
 
 
 {% endblock %}


### PR DESCRIPTION
This pull request adds the functionality of having the Webpay form as a symfony Form. Henc,e all the logic inside the WebpayController has been modified to handle it properly. Views have been modified as well.

Flow:
- Form submission with a number -> it will show the data coming from the form in twig dump.
- form submission with something different than a number -> Form is not valid -> the user sees the error under the form field.